### PR TITLE
Flesh out documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,35 @@ Currently Keyring supports the following backends
 
 ## Usage
 
-Something on how to use it or link to godocs
+The short version of how to use keyring is shown below.
+
+```go
+  ring, _ := keyring.Open("example", keyring.KeychainBackend)
+
+  _ = ring.Set(keyring.Item{
+    Key: "foo",
+    Data: []byte("secret-bar"),
+  })
+
+	i, _ := ring.Get("foo")
+
+	fmt.Printf("%s", i.Data)
+```
+
+For more detail on the API please check [the keyring godocs](https://godoc.org/github.com/99designs/keyring)
 
 ## Development & Contributing
 
-  * TODO local dev
-  * TODO branch/PR ettiquette
+Contributions to the keyring package are most welcome from engineers of all backgrounds and skill levels. In particular the addition of extra backends across popular operating systems would be appreciated.
 
+This project will adhere to the [Go Community Code of Conduct](https://golang.org/conduct) in the github provided discussion spaces, with the moderators being the 99designs engineering leadership team, currently lead by [John Barton](mailto:john.barton@99designs.com).
+
+To make a contribution:
+
+  * Fork the repository
+  * Make your changes on the fork
+  * Submit a pull request back to this repo with a clear description of the problem you're solving
+  * Ensure your PR passes all current (and new) tests
+  * Ideally verify that [aws-vault](https://github.com/99designs/aws-vault) works with your changes (optional)
+
+...and we'll do our best to get your work merged in

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Keyring
+Keyring [![Build Status](https://travis-ci.org/99designs/keyring.svg?branch=master)](https://travis-ci.org/99designs/keyring)
 =======
 
 Keyring provides utility functions for and a common interface to a range of secure credential storage services. Originally developed as part of [AWS Vault](https://github.com/99designs/aws-vault), a command line tool for securely managing AWS access from developer workstations.
@@ -21,5 +21,4 @@ Something on how to use it or link to godocs
 
   * TODO local dev
   * TODO branch/PR ettiquette
-  * TODO CI
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 Keyring
 =======
 
-What it does
+Keyring provides utility functions for and a common interface to a range of secure credential storage services. Originally developed as part of [AWS Vault](https://github.com/99designs/aws-vault), a command line tool for securely managing AWS access from developer workstations.
+
+Currently Keyring supports the following backends
+  * macOS/OSX Keychain
+  * [Secret Service](https://github.com/99designs/aws-vault/pull/98)
+  * [KDE Wallet](https://github.com/99designs/aws-vault/pull/27)
+  * [Encrypted File](https://github.com/99designs/aws-vault/pull/63)
 
 ## Installing
 
@@ -17,7 +23,3 @@ Something on how to use it or link to godocs
   * TODO branch/PR ettiquette
   * TODO CI
 
-## References and Inspiration
-
- * Extracted from https://github.com/99designs/aws-vault
- * https://github.com/pda/aws-keychain

--- a/array.go
+++ b/array.go
@@ -1,9 +1,14 @@
 package keyring
 
+// ArrayKeyring is a mock/non-secure backend that meets the Keyring interface.
+// It is intended to be used to aid unit testing of code that relies on the package.
+// NOTE: Do not use in production code
 type ArrayKeyring struct {
 	items map[string]Item
 }
 
+// NewArrayKeyring returns an ArrayKeyring, optionally constructed with an initial slice
+// of items
 func NewArrayKeyring(initial []Item) *ArrayKeyring {
 	kr := &ArrayKeyring{}
 	for _, i := range initial {
@@ -12,6 +17,7 @@ func NewArrayKeyring(initial []Item) *ArrayKeyring {
 	return kr
 }
 
+// Get returns an Item matching Key
 func (k *ArrayKeyring) Get(key string) (Item, error) {
 	if i, ok := k.items[key]; ok {
 		return i, nil
@@ -19,6 +25,7 @@ func (k *ArrayKeyring) Get(key string) (Item, error) {
 	return Item{}, ErrKeyNotFound
 }
 
+// Set will store an item on the mock Keyring
 func (k *ArrayKeyring) Set(i Item) error {
 	if k.items == nil {
 		k.items = map[string]Item{}
@@ -27,11 +34,13 @@ func (k *ArrayKeyring) Set(i Item) error {
 	return nil
 }
 
+// Remove will delete an Item from the Keyring
 func (k *ArrayKeyring) Remove(key string) error {
 	delete(k.items, key)
 	return nil
 }
 
+// Keys provides a slice of all Item keys on the Keyring
 func (k *ArrayKeyring) Keys() ([]string, error) {
 	var keys = []string{}
 	for key := range k.items {

--- a/keychain_test.go
+++ b/keychain_test.go
@@ -151,5 +151,6 @@ func deleteKeychain(path string, t *testing.T) {
 }
 
 func tempPath() string {
+	// TODO make filename configurable
 	return filepath.Join(os.TempDir(), fmt.Sprintf("aws-vault-test-%d.keychain", time.Now().UnixNano()))
 }

--- a/keyring.go
+++ b/keyring.go
@@ -1,7 +1,11 @@
+// Package keyring provides a uniform API over a range of desktop credential storage engines
+//
+// See project homepage at https://github.com/99designs/keyring for more background
 package keyring
 
 import "errors"
 
+// All currently supported secure storage backends
 const (
 	SecretServiceBackend string = "secret-service"
 	KeychainBackend      string = "keychain"
@@ -9,10 +13,12 @@ const (
 	FileBackend          string = "file"
 )
 
+// DefaultBackend is the lowest common denominator across OSes - encrypted file
 var DefaultBackend = FileBackend
 
 var supportedBackends = map[string]opener{}
 
+// SupportedBackends provides a slice of all available backend keys on the current OS
 func SupportedBackends() []string {
 	b := []string{}
 	for k := range supportedBackends {
@@ -23,6 +29,7 @@ func SupportedBackends() []string {
 
 type opener func(name string) (Keyring, error)
 
+// Open will ask the underlying backend to authenticate and provide access to the underlying store
 func Open(name string, backend string) (Keyring, error) {
 	op, ok := supportedBackends[backend]
 	if !ok {
@@ -32,6 +39,7 @@ func Open(name string, backend string) (Keyring, error) {
 	return op(name)
 }
 
+// Item is an, uh, item that is stored on the keyring
 type Item struct {
 	Key         string
 	Data        []byte
@@ -40,12 +48,20 @@ type Item struct {
 	TrustSelf   bool
 }
 
+// Keyring provides the uniform interface over the underlying backends
 type Keyring interface {
+	// Returns an Item matching the key or ErrKeyNotFound
 	Get(key string) (Item, error)
+	// Stores an Item on the keyring
 	Set(item Item) error
+	// Removes the item with matching key
 	Remove(key string) error
+	// Provides a slice of all keys stored on the keyring
 	Keys() ([]string, error)
 }
 
+// ErrNoAvailImpl is returned by Open when a backend cannot be found
 var ErrNoAvailImpl = errors.New("Specified keyring backend not available")
+
+// ErrKeyNotFound is returned by Keyring Get when the item is not on the keyring
 var ErrKeyNotFound = errors.New("The specified item could not be found in the keyring.")

--- a/keyring.go
+++ b/keyring.go
@@ -45,7 +45,8 @@ type Item struct {
 	Data        []byte
 	Label       string
 	Description string
-	TrustSelf   bool
+	// macOS only, set false if you want the password prompt to appear every time
+	TrustSelf bool
 }
 
 // Keyring provides the uniform interface over the underlying backends

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -1,0 +1,25 @@
+package keyring_test
+
+import (
+	"fmt"
+
+	"github.com/99designs/keyring"
+)
+
+func ExampleKeyringGet() {
+	// Imagine instead this was a keyring.Open("example", keyring.KeychainBackend)
+	var ring keyring.Keyring = keyring.NewArrayKeyring([]keyring.Item{
+		keyring.Item{
+			Key:  "foo",
+			Data: []byte("secret-bar"),
+		},
+	})
+
+	i, err := ring.Get("foo")
+
+	if err == nil {
+		fmt.Printf("%s", i.Data)
+	}
+
+	// Output: secret-bar
+}

--- a/kwallet.go
+++ b/kwallet.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aulanov/go.dbus"
 )
 
+// TODO change APPID/FOLDER from consts to configuration
 const (
 	DBUS_SERVICE_NAME = "org.kde.kwalletd"
 	DBUS_PATH         = "/modules/kwalletd"


### PR DESCRIPTION
Now that Keyring has been extracted out to a fully fledged package I'm trying to bring the docs up to scratch. Still needs a fair bit of work. @lox I'd appreciate any input here that could help, I've mostly been reading the code and trying to capture the intent.

I did notice a few constants that fell on the wrong side of the aws-vault split which I'll clean up in a later PR.