### PR TITLE
Use govendor status to check vendor.json is correct

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
+set -eu
 
-rm -rf $(find vendor/* -maxdepth 0 ! -name 'vendor.json')
-
-go get -u github.com/kardianos/govendor
-govendor sync
-
-CHANGES=`git diff`
-if [ -n "$CHANGES" ] ; then
-    echo "vendor does not match the lock:"
-    echo $CHANGES
-    exit 1
-fi
+go get github.com/kardianos/govendor
+govendor status


### PR DESCRIPTION
The previous approach for verifying integrity of `vendor/` was pretty heavy-weight, it blows out build times by a lot and fails if any of the upstream dependencies fail to fetch. Beyond that, it fails when there are GOOS specific packages.

This moves the check to use `govendor status` which will check the filesystem against the shasums in the vendor.json and error if they aren't up to date.

Simpler/faster!