### PR TITLE
Set `isTrusted` when keychain sets KeychainTrustApplication:

### DIFF
--- a/keychain.go
+++ b/keychain.go
@@ -29,6 +29,9 @@ func init() {
 		if cfg.KeychainName != "" {
 			kc.path = cfg.KeychainName + ".keychain"
 		}
+		if cfg.KeychainTrustApplication {
+			kc.isTrusted = true
+		}
 		return kc, nil
 	})
 }


### PR DESCRIPTION
The `keychain` type has a field `isTrusted` which is
used in determining whether the keychain should be configured to trust
the calling application when setting items, like:

```
isTrusted := k.isTrusted && !item.KeychainNotTrustApplication
```

However, this field `k.isTrusted` is never set anywhere else in the
codebase and therefore the above conditional always returns false.

I have used the config field `KeychainTrustApplication` to determine
the value of `k.isTrusted`.  This config field was previously unused,
but can now be used to properly set the ACL when setting items.