### PR TITLE
fix func input to match opener

### DIFF
--- a/wincred.go
+++ b/wincred.go
@@ -13,7 +13,8 @@ type windowsKeyring struct {
 }
 
 func init() {
-	supportedBackends[WinCredBackend] = opener(func(name string) (Keyring, error) {
+	supportedBackends[WinCredBackend] = opener(func(cfg Config) (Keyring, error) {
+		name := cfg.ServiceName
 		if name == "" {
 			name = "default"
 		}
@@ -22,8 +23,6 @@ func init() {
 			name: name,
 		}, nil
 	})
-
-	DefaultBackend = WinCredBackend
 }
 
 func (k *windowsKeyring) Get(key string) (Item, error) {


### PR DESCRIPTION
These are the changes that I have to make to make it compile project [https://github.com/segmentio/aws-okta](url) in windows. I updated the returned func to match opener type. 

I also removed this line since it's not defined and used.

> DefaultBackend = WinCredBackend
