### PR TITLE
Add cgo build tag for crosscompiles

### DIFF
--- a/keychain.go
+++ b/keychain.go
@@ -1,4 +1,4 @@
-// +build darwin
+// +build darwin,cgo
 
 package keyring
 


### PR DESCRIPTION
go-keychain is all cgo as of right now, so attempting to cross-compile a darwin executable of aws-vault on linux results in errors about undefined functions. If the cgo build tag is added here, linux cross-compiles of darwin complete successfully (albeit without keychain functionality). I am interested in this because I want transparent access across a host macbook and multiple vagrant machines running on it with the .aws-vault directory mapped into them, which seemed to work after I compiled binaries including this change.