### PR TITLE
Replaced the use log.Printf, to  debugf

### DIFF
--- a/keychain.go
+++ b/keychain.go
@@ -4,7 +4,6 @@ package keyring
 
 import (
 	"fmt"
-	"log"
 
 	gokeychain "github.com/keybase/go-keychain"
 )
@@ -161,7 +160,7 @@ func (k *keychain) Remove(key string) error {
 		item.SetMatchSearchList(kc)
 	}
 
-	log.Printf("Removing keychain item service=%q, account=%q, keychain %q", k.service, key, k.path)
+	debugf("Removing keychain item service=%q, account=%q, keychain %q", k.service, key, k.path)
 	return gokeychain.DeleteItem(item)
 }
 


### PR DESCRIPTION
Replaced the use log.Printf inside Keychain remove to use  debugf. This will allow the glabal Debug flag to work as intended.