### PR TITLE
Fail at Open instead of Get if the backend isn't available

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -44,7 +44,12 @@ func Open(cfg Config) (Keyring, error) {
 	debugf("Considering backends: %v", cfg.AllowedBackends)
 	for _, backend := range cfg.AllowedBackends {
 		if opener, ok := supportedBackends[backend]; ok {
-			return opener(cfg)
+			openBackend, err := opener(cfg)
+			if err != nil {
+				debugf("Failed backend %s: %s", backend, err)
+				continue
+			}
+			return openBackend, nil
 		}
 	}
 	return nil, ErrNoAvailImpl

--- a/kwallet.go
+++ b/kwallet.go
@@ -38,12 +38,14 @@ func init() {
 			return nil, err
 		}
 
-		return &kwalletKeyring{
+		ring := &kwalletKeyring{
 			wallet: *wallet,
 			name:   cfg.ServiceName,
 			appID:  cfg.KWalletAppID,
 			folder: cfg.KWalletFolder,
-		}, nil
+		}
+
+		return ring, ring.openWallet()
 	})
 }
 

--- a/libsecret.go
+++ b/libsecret.go
@@ -30,10 +30,12 @@ func init() {
 			return &secretsKeyring{}, err
 		}
 
-		return &secretsKeyring{
+		ring := &secretsKeyring{
 			name:    cfg.LibSecretCollectionName,
 			service: service,
-		}, nil
+		}
+
+		return ring, ring.openSecrets()
 	})
 }
 


### PR DESCRIPTION
Without this fix, every non-kwallet user must override the available backends, because kwallet will be chosen automatically despite it not running. (This generally results in secret storage silently not working, because aws-vault and other users don't consider missing creds to be an error)

I'm not sure how to write a test in this repo for it (suggestions?) but I validated it against aws-vault, which finally allows me to unset the `AWS_VAULT_BACKEND` var:
```
mike@tc2:go/src/github.com/99designs/aws-vault> ./aws-vault --debug list
2018/06/12 14:14:12 [keyring] Considering backends: [kwallet secret-service file]
2018/06/12 14:14:12 [keyring] Failed backend kwallet: The name org.kde.kwalletd was not provided by any .service files
2018/06/12 14:14:12 Loading config file /home/mike/.aws/config
2018/06/12 14:14:12 Parsing config file /home/mike/.aws/config
2018/06/12 14:14:12 Looking up all keys in keyring
Profile                  Credentials              Sessions                 
=======                  ===========              ========                 
default                  -                                                 
<omitted the rest of my profiles, but they're here :)>
```