### PR TITLE
Add GetMetadata API; implement for keychain+file

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -6,6 +6,7 @@ package keyring
 import (
 	"errors"
 	"log"
+	"time"
 )
 
 // All currently supported secure storage backends
@@ -67,10 +68,22 @@ type Item struct {
 	KeychainNotSynchronizable   bool
 }
 
+// Metadata is information about a thing stored on the keyring; retrieving
+// metadata must not require authentication.  The embedded Item should be
+// filled in with an empty Data field.
+// It's allowed for Item to be a nil pointer, indicating that all we
+// have is the timestamps.
+type Metadata struct {
+	*Item
+	ModificationTime time.Time
+}
+
 // Keyring provides the uniform interface over the underlying backends
 type Keyring interface {
 	// Returns an Item matching the key or ErrKeyNotFound
 	Get(key string) (Item, error)
+	// Returns the non-secret parts of an Item
+	GetMetadata(key string) (Metadata, error)
 	// Stores an Item on the keyring
 	Set(item Item) error
 	// Removes the item with matching key
@@ -84,6 +97,10 @@ var ErrNoAvailImpl = errors.New("Specified keyring backend not available")
 
 // ErrKeyNotFound is returned by Keyring Get when the item is not on the keyring
 var ErrKeyNotFound = errors.New("The specified item could not be found in the keyring.")
+
+// ErrMetadataNeedsCredentials is returned when Metadata is called against a
+// backend which requires credentials even to see metadata.
+var ErrMetadataNeedsCredentials = errors.New("The keyring backend requires credentials for metadata access")
 
 var (
 	// Whether to print debugging output


### PR DESCRIPTION
A new `GetMetadata()` API exports a new `Metadata` type.  The `Metadata` items can embed a `*Item`, which is permitted to be nil if no `Item` fields at all can be retrieved without prompting.

`GetMetadata` should always be safe to call without needing to authenticate and thus is suitable for use in batch workflows.

Implement `GetMetadata` for file and keychain backends.

Note: the keychain backend requires an updated `go-keychain` library, not yet vendored into this repo, and requires Go 1.10 to build.