### PR TITLE
Add GetMetadata API

### DIFF
--- a/keychain.go
+++ b/keychain.go
@@ -72,6 +72,40 @@ func (k *keychain) Get(key string) (Item, error) {
 	return item, nil
 }
 
+func (k *keychain) GetMetadata(key string) (Metadata, error) {
+	query := gokeychain.NewItem()
+	query.SetSecClass(gokeychain.SecClassGenericPassword)
+	query.SetService(k.service)
+	query.SetAccount(key)
+	query.SetMatchLimit(gokeychain.MatchLimitOne)
+	query.SetReturnAttributes(true)
+	query.SetReturnData(false)
+	query.SetReturnRef(true)
+
+	debugf("Querying keychain for metadata of service=%q, account=%q, keychain=%q", k.service, key, k.path)
+	results, err := gokeychain.QueryItem(query)
+	if err == gokeychain.ErrorItemNotFound || len(results) == 0 {
+		debugf("No results found")
+		return Metadata{}, ErrKeyNotFound
+	} else if err != nil {
+		debugf("Error: %#v", err)
+		return Metadata{}, err
+	}
+
+	md := Metadata{
+		Item: &Item{
+			Key:         key,
+			Label:       results[0].Label,
+			Description: results[0].Description,
+		},
+		ModificationTime: results[0].ModificationDate,
+	}
+
+	debugf("Found metadata for %q", md.Item.Label)
+
+	return md, nil
+}
+
 func (k *keychain) Set(item Item) error {
 	var kc gokeychain.Keychain
 

--- a/keyring.go
+++ b/keyring.go
@@ -6,6 +6,7 @@ package keyring
 import (
 	"errors"
 	"log"
+	"time"
 )
 
 // All currently supported secure storage backends
@@ -67,10 +68,22 @@ type Item struct {
 	KeychainNotSynchronizable   bool
 }
 
+// Metadata is information about a thing stored on the keyring; retrieving
+// metadata must not require authentication.  The embedded Item should be
+// filled in with an empty Data field.
+// It's allowed for Item to be a nil pointer, indicating that all we
+// have is the timestamps.
+type Metadata struct {
+	*Item
+	ModificationTime time.Time
+}
+
 // Keyring provides the uniform interface over the underlying backends
 type Keyring interface {
 	// Returns an Item matching the key or ErrKeyNotFound
 	Get(key string) (Item, error)
+	// Returns the non-secret parts of an Item
+	GetMetadata(key string) (Metadata, error)
 	// Stores an Item on the keyring
 	Set(item Item) error
 	// Removes the item with matching key
@@ -84,6 +97,10 @@ var ErrNoAvailImpl = errors.New("Specified keyring backend not available")
 
 // ErrKeyNotFound is returned by Keyring Get when the item is not on the keyring
 var ErrKeyNotFound = errors.New("The specified item could not be found in the keyring.")
+
+// ErrMetadataNeedsCredentials is returned when Metadata is called against a
+// backend which requires credentials even to see metadata.
+var ErrMetadataNeedsCredentials = errors.New("The keyring backend requires credentials for metadata access")
 
 var (
 	// Whether to print debugging output

--- a/kwallet.go
+++ b/kwallet.go
@@ -94,6 +94,16 @@ func (k *kwalletKeyring) Get(key string) (Item, error) {
 	return item, nil
 }
 
+// GetMetadata for kwallet returns an error indicating that it's unsupported
+// for this backend.
+//
+// The only APIs found around KWallet are for retrieving content, no indication
+// found in docs for methods to use to retrieve metadata without needing unlock
+// credentials.
+func (k *kwalletKeyring) GetMetadata(_ string) (Metadata, error) {
+	return Metadata{}, ErrMetadataNeedsCredentials
+}
+
 func (k *kwalletKeyring) Set(item Item) error {
 	err := k.openWallet()
 	if err != nil {

--- a/libsecret.go
+++ b/libsecret.go
@@ -137,6 +137,18 @@ func (k *secretsKeyring) Get(key string) (Item, error) {
 	return ret, err
 }
 
+// GetMetadata for libsecret returns an error indicating that it's unsupported
+// for this backend.
+//
+// libsecret actually implements a metadata system which we could use, "Secret
+// Attributes"; I found no indication in documentation of anything like an
+// automatically maintained last-modification timestamp, so to use this we'd
+// need to have a SetMetadata API too.  Which we're not yet doing, but feel
+// free to contribute patches.
+func (k *secretsKeyring) GetMetadata(key string) (Metadata, error) {
+	return Metadata{}, ErrMetadataNeedsCredentials
+}
+
 func (k *secretsKeyring) Set(item Item) error {
 	err := k.openSecrets()
 	if err != nil {


### PR DESCRIPTION
A new `GetMetadata()` API exports a new `Metadata` type.  The `Metadata` items can embed a `*Item`, which is permitted to be nil if no `Item` fields at all can be retrieved without prompting.

`GetMetadata` should always be safe to call without needing to authenticate and thus is suitable for use in batch workflows.

Implement `GetMetadata` for file and keychain backends.  
For Linux, stub out the call and return an error.

The code builds on Linux but GetMetadata is unusable; the libsecret API potentially could be used, if coupled with a SetMetadata API too.

For keychain, this version now adapts to the variation of my patch which keybase/go-keychain merged, where they switched the struct field names.

nb: this is a redo of #26 which was reverted after it was merged after go-keychain landed the new API but before adapting to the changed struct field names as they landed.