### PR TITLE
map InvalidBackend to (default) empty string

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -10,7 +10,7 @@ import (
 
 // All currently supported secure storage backends
 const (
-	InvalidBackend       BackendType = "invalid"
+	InvalidBackend       BackendType = ""
 	SecretServiceBackend BackendType = "secret-service"
 	KeychainBackend      BackendType = "keychain"
 	KWalletBackend       BackendType = "kwallet"


### PR DESCRIPTION
this means that by *default*, if anyone's using a `BackendType` and
they've forgotten to initialize it (like on a struct, for example), then
the default empty string will automatically compare equal to `InvalidBackend`

Otherwise, if code wants to switch on the backend type, really they've
gotta check for `InvalidBackend` *and* empty string `""`