### PR TITLE
DISABLE_KWALLET Environment Variable for ChromeOS

### DIFF
--- a/kwallet.go
+++ b/kwallet.go
@@ -4,6 +4,7 @@ package keyring
 
 import (
 	"encoding/json"
+	"os"
 
 	"github.com/aulanov/go.dbus"
 )
@@ -14,6 +15,11 @@ const (
 )
 
 func init() {
+
+	if os.Getenv("DISABLE_KWALLET") == "1" {
+		return
+	}
+
 	// silently fail if dbus isn't available
 	_, err := dbus.SessionBus()
 	if err != nil {


### PR DESCRIPTION
On ChromeOS, `aws-vault` seg faults on line 23 below from `dbus.SessionBus()`.  Since kwallet isn't used in ChromeOS, an environment variable is a simple way to get `aws-vault` to work on ChromeOS.  I've tested and it now works using `DISABLE_KWALLET=1 go run main.go login default`.  If DISABLE_KWALLET is set to 1, it simply skips the rest of the init code.  `aws-vault` docs would need to be updated, too.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6329a2]

goroutine 1 [running]:
github.com/99designs/aws-vault/vendor/github.com/aulanov/go%2edbus.getTransport(0xc4200240a9, 0x9, 0x1, 0xc42006de38, 0x488afd, 0x9a351e)
        /home/chronos/user/Downloads/go/src/github.com/99designs/aws-vault/vendor/github.com/aulanov/go.dbus/conn.go:590 +0x152
github.com/99designs/aws-vault/vendor/github.com/aulanov/go%2edbus.Dial(0xc4200240a9, 0x9, 0xc4200240a9, 0x9, 0xc42006de88)
        /home/chronos/user/Downloads/go/src/github.com/99designs/aws-vault/vendor/github.com/aulanov/go.dbus/conn.go:142 +0x39
github.com/99designs/aws-vault/vendor/github.com/aulanov/go%2edbus.SessionBusPrivate(0x8, 0x9bb368, 0xc42006dec0)
        /home/chronos/user/Downloads/go/src/github.com/99designs/aws-vault/vendor/github.com/aulanov/go.dbus/conn.go:96 +0x5d
github.com/99designs/aws-vault/vendor/github.com/aulanov/go%2edbus.SessionBus(0x0, 0x0, 0x0)
        /home/chronos/user/Downloads/go/src/github.com/99designs/aws-vault/vendor/github.com/aulanov/go.dbus/conn.go:76 +0xad
github.com/99designs/aws-vault/vendor/github.com/99designs/keyring.init.1()
        /home/chronos/user/Downloads/go/src/github.com/99designs/aws-vault/vendor/github.com/99designs/keyring/kwallet.go:24 +0x56
exit status 2
```