### PR TITLE
Give the backend selection proccess a deterministic behavior.

### DIFF
--- a/keyring.go
+++ b/keyring.go
@@ -19,6 +19,21 @@ const (
 	PassBackend          BackendType = "pass"
 )
 
+// This order makes sure the OS-specific backends
+// are picked over the more generic backends.
+var backendOrder = []BackendType{
+	// Windows
+	WinCredBackend,
+	// MacOS
+	KeychainBackend,
+	// Linux
+	SecretServiceBackend,
+	KWalletBackend,
+	// General
+	PassBackend,
+	FileBackend,
+}
+
 type BackendType string
 
 var supportedBackends = map[BackendType]opener{}
@@ -26,13 +41,13 @@ var supportedBackends = map[BackendType]opener{}
 // AvailableBackends provides a slice of all available backend keys on the current OS
 func AvailableBackends() []BackendType {
 	b := []BackendType{}
-	for k := range supportedBackends {
-		if k != FileBackend {
+	for _, k := range backendOrder {
+		_, ok := supportedBackends[k]
+		if ok {
 			b = append(b, k)
 		}
 	}
-	// make sure FileBackend is last
-	return append(b, FileBackend)
+	return b
 }
 
 type opener func(cfg Config) (Keyring, error)


### PR DESCRIPTION
This is a fix for #35. I saw that you already had an incomplete branch that addressed the same problem by ordering the backends. Maybe this simpler approach works for you?

I guess the order is up for debate but at least this gives the whole process some predictability.