### PR TITLE
Add a WinCredPrefix config and remove the default of aws-vault

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,4 +46,7 @@ type Config struct {
 
 	// PassPrefix is a string prefix to prepend to the item path stored in pass
 	PassPrefix string
+
+	// WinCredPrefix is a string prefix to prepend to the key name
+	WinCredPrefix string
 }

--- a/wincred.go
+++ b/wincred.go
@@ -9,7 +9,8 @@ import (
 )
 
 type windowsKeyring struct {
-	name string
+	name   string
+	prefix string
 }
 
 func init() {
@@ -19,8 +20,14 @@ func init() {
 			name = "default"
 		}
 
+		prefix := cfg.WinCredPrefix
+		if prefix == "" {
+			prefix = "keyring"
+		}
+
 		return &windowsKeyring{
-			name: name,
+			name:   name,
+			prefix: prefix,
 		}, nil
 	})
 }
@@ -75,5 +82,5 @@ func (k *windowsKeyring) Keys() ([]string, error) {
 }
 
 func (k *windowsKeyring) credentialName(key string) string {
-	return "aws-vault:" + k.name + ":" + key
+	return k.prefix + ":" + k.name + ":" + key
 }


### PR DESCRIPTION
Looks like we had a hard-coded reference to aws-vault left in the wincred credentials. 

This makes that value configurable and closes #38.