### PR TITLE
match Get() API in libsecret and keychain, and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/array.go
+++ b/array.go
@@ -48,3 +48,7 @@ func (k *ArrayKeyring) Keys() ([]string, error) {
 	}
 	return keys, nil
 }
+
+func (k *ArrayKeyring) GetMetadata(_ string) (Metadata, error) {
+	return Metadata{}, ErrMetadataNeedsCredentials
+}

--- a/keychain.go
+++ b/keychain.go
@@ -218,7 +218,7 @@ func (k *keychain) Keys() ([]string, error) {
 
 		if err := kc.Status(); err != nil {
 			if err == gokeychain.ErrorNoSuchKeychain {
-				return nil, ErrKeyNotFound
+				return []string{}, nil
 			}
 			return nil, err
 		}
@@ -236,10 +236,6 @@ func (k *keychain) Keys() ([]string, error) {
 	accountNames := make([]string, len(results))
 	for idx, r := range results {
 		accountNames[idx] = r.Account
-	}
-
-	if len(accountNames) == 0 {
-		return accountNames, ErrKeyNotFound
 	}
 
 	return accountNames, nil

--- a/keychain.go
+++ b/keychain.go
@@ -193,6 +193,9 @@ func (k *keychain) Remove(key string) error {
 		kc := gokeychain.NewWithPath(k.path)
 
 		if err := kc.Status(); err != nil {
+			if err == gokeychain.ErrorNoSuchKeychain {
+				return ErrKeyNotFound
+			}
 			return err
 		}
 
@@ -214,6 +217,9 @@ func (k *keychain) Keys() ([]string, error) {
 		kc := gokeychain.NewWithPath(k.path)
 
 		if err := kc.Status(); err != nil {
+			if err == gokeychain.ErrorNoSuchKeychain {
+				return nil, ErrKeyNotFound
+			}
 			return nil, err
 		}
 
@@ -230,6 +236,10 @@ func (k *keychain) Keys() ([]string, error) {
 	accountNames := make([]string, len(results))
 	for idx, r := range results {
 		accountNames[idx] = r.Account
+	}
+
+	if len(accountNames) == 0 {
+		return accountNames, ErrKeyNotFound
 	}
 
 	return accountNames, nil

--- a/keychain_test.go
+++ b/keychain_test.go
@@ -9,8 +9,6 @@ import (
 	"reflect"
 	"testing"
 	"time"
-
-	gokeychain "github.com/keybase/go-keychain"
 )
 
 func TestOSXKeychainKeyringSet(t *testing.T) {
@@ -117,10 +115,8 @@ func TestOSXKeychainKeyringListKeysWhenEmpty(t *testing.T) {
 	}
 
 	_, err := k.Keys()
-	// TODO: we should consider making a generic package error like keyring.ErrNoKeyChain instead of letting
-	//       the go-keychain lib's internal errors leak through. We do this for a few other error types.
-	if err != gokeychain.ErrorNoSuchKeychain {
-		t.Fatal("expected gokeychain.ErrorNoSuchKeychain")
+	if err != ErrKeyNotFound {
+		t.Fatalf("expected ErrKeyNotFound, got: %v", err)
 	}
 }
 
@@ -229,10 +225,8 @@ func TestOSXKeychainRemoveKeyWhenEmpty(t *testing.T) {
 	}
 
 	err := k.Remove("no-such-key")
-	// TODO: we should consider making a generic package error like keyring.ErrNoKeyChain instead of letting
-	//       the go-keychain lib's internal errors leak through. We do this for a few other error types.
-	if err != gokeychain.ErrorNoSuchKeychain {
-		t.Fatal("expected gokeychain.ErrorNoSuchKeychain")
+	if err != ErrKeyNotFound {
+		t.Fatalf("expected ErrKeyNotFound, got: %v", err)
 	}
 }
 

--- a/keychain_test.go
+++ b/keychain_test.go
@@ -114,9 +114,12 @@ func TestOSXKeychainKeyringListKeysWhenEmpty(t *testing.T) {
 		isTrusted:    true,
 	}
 
-	_, err := k.Keys()
-	if err != ErrKeyNotFound {
-		t.Fatalf("expected ErrKeyNotFound, got: %v", err)
+	keys, err := k.Keys()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("Expected 0 keys, got %d", len(keys))
 	}
 }
 

--- a/libsecret.go
+++ b/libsecret.go
@@ -241,7 +241,7 @@ func (k *secretsKeyring) Remove(key string) error {
 func (k *secretsKeyring) Keys() ([]string, error) {
 	if err := k.openCollection(); err != nil {
 		if err == errCollectionNotFound {
-			return []string{}, ErrKeyNotFound
+			return []string{}, nil
 		}
 		return []string{}, err
 	}

--- a/libsecret.go
+++ b/libsecret.go
@@ -54,7 +54,7 @@ func (e *secretsError) Error() string {
 	return e.message
 }
 
-var ErrCollectionNotFound = errors.New("The collection does not exist. Please add a key first")
+var errCollectionNotFound = errors.New("The collection does not exist. Please add a key first")
 
 func (k *secretsKeyring) openSecrets() error {
 	session, err := k.service.Open()
@@ -87,7 +87,7 @@ func (k *secretsKeyring) openCollection() error {
 	}
 
 	if k.collection == nil {
-		return ErrCollectionNotFound
+		return errCollectionNotFound
 		// return &secretsError{fmt.Sprintf(
 		// 	"The collection %q does not exist. Please add a key first",
 		// 	k.name,
@@ -99,7 +99,7 @@ func (k *secretsKeyring) openCollection() error {
 
 func (k *secretsKeyring) Get(key string) (Item, error) {
 	if err := k.openCollection(); err != nil {
-		if err == ErrCollectionNotFound {
+		if err == errCollectionNotFound {
 			return Item{}, ErrKeyNotFound
 		}
 		return Item{}, err
@@ -199,8 +199,10 @@ func (k *secretsKeyring) Set(item Item) error {
 }
 
 func (k *secretsKeyring) Remove(key string) error {
-	err := k.openCollection()
-	if err != nil {
+	if err := k.openCollection(); err != nil {
+		if err == errCollectionNotFound {
+			return ErrKeyNotFound
+		}
 		return err
 	}
 
@@ -237,8 +239,10 @@ func (k *secretsKeyring) Remove(key string) error {
 }
 
 func (k *secretsKeyring) Keys() ([]string, error) {
-	err := k.openCollection()
-	if err != nil {
+	if err := k.openCollection(); err != nil {
+		if err == errCollectionNotFound {
+			return []string{}, ErrKeyNotFound
+		}
 		return []string{}, err
 	}
 

--- a/libsecret.go
+++ b/libsecret.go
@@ -252,3 +252,11 @@ func (k *secretsKeyring) Keys() ([]string, error) {
 
 	return keys, nil
 }
+
+// deleteCollection deletes the keyring's collection if it exists. This is mainly to support testing.
+func (k *secretsKeyring) deleteCollection() error {
+	if err := k.openCollection(); err != nil {
+		return err
+	}
+	return k.collection.Delete()
+}

--- a/libsecret_test.go
+++ b/libsecret_test.go
@@ -1,0 +1,115 @@
+// +build linux
+
+package keyring
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/gsterjov/go-libsecret"
+)
+
+// NOTE: These tests are not runnable from a headless environment such as
+// Docker or a CI pipeline due to the DBus "prompt" interface being called
+// by the underlying go-libsecret when creating and unlocking a keychain.
+//
+// TODO: Investigate a way to automate the prompting. Some ideas:
+//
+//  1. I've looked extensively but have not found a headless CLI tool that
+//     could be run in the background of eg: a docker container
+//  2. It might be possible to make a mock prompter that connects to DBus
+//     and provides the Prompt interface using the go-libsecret library.
+
+func libSecretSetup(t *testing.T) (Keyring, func(t *testing.T)) {
+	service, err := libsecret.NewService()
+	if err != nil {
+		t.Fatal(err)
+	}
+	kr := &secretsKeyring{
+		name:    "keyring-test",
+		service: service,
+	}
+	return kr, func(t *testing.T) {
+		if err := kr.deleteCollection(); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestLibSecretKeysWhenEmpty(t *testing.T) {
+	kr, _ := libSecretSetup(t)
+
+	_, err := kr.Keys()
+	// TODO: consider making Keys() return ErrNoSuchKey similar to when Get() is called before a keychain exists
+	if err == nil {
+		t.Fatal("expected keyring.secretsError")
+	}
+}
+
+func TestLibSecretKeysWhenNotEmpty(t *testing.T) {
+	kr, teardown := libSecretSetup(t)
+	defer teardown(t)
+
+	item := Item{Key: "llamas", Data: []byte("llamas are great")}
+	item2 := Item{Key: "alpacas", Data: []byte("alpacas are better")}
+
+	if err := kr.Set(item); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := kr.Set(item2); err != nil {
+		t.Fatal(err)
+	}
+
+	keys, err := kr.Keys()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(keys) != 2 {
+		t.Fatalf("Expected 2 keys, got %d", len(keys))
+	}
+
+	sort.Strings(keys)
+	if keys[0] != "alpacas" {
+		t.Fatalf("Expected alpacas")
+	}
+	if keys[1] != "llamas" {
+		t.Fatalf("Expected llamas")
+	}
+}
+
+func TestLibSecretGetWhenEmpty(t *testing.T) {
+	kr, _ := libSecretSetup(t)
+
+	_, err := kr.Get("llamas")
+	if err != ErrKeyNotFound {
+		t.Fatal("Expected ErrKeyNotFound")
+	}
+}
+
+func TestLibSecretGetWhenNotEmpty(t *testing.T) {
+	kr, teardown := libSecretSetup(t)
+	defer teardown(t)
+
+	item := Item{Key: "llamas", Data: []byte("llamas are great")}
+
+	if err := kr.Set(item); err != nil {
+		t.Fatal(err)
+	}
+
+	it, err := kr.Get(item.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if it.Key != item.Key {
+		t.Fatal("Expected item not returned")
+	}
+}
+
+// func TestLibSecretRemoveWhenEmpty(t *testing.T) {
+// 	kr, _ := libSecretSetup(t)
+
+// }
+
+// func TestLibSecretRemoveWhenNotEmpty(t *testing.T) {}

--- a/libsecret_test.go
+++ b/libsecret_test.go
@@ -44,9 +44,12 @@ func libSecretSetup(t *testing.T) (Keyring, func(t *testing.T)) {
 func TestLibSecretKeysWhenEmpty(t *testing.T) {
 	kr, _ := libSecretSetup(t)
 
-	_, err := kr.Keys()
-	if err != ErrKeyNotFound {
-		t.Fatalf("Expected ErrKeyNotFound, got: %s", err)
+	keys, err := kr.Keys()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("Expected 0 keys, got %d", len(keys))
 	}
 }
 

--- a/libsecret_test.go
+++ b/libsecret_test.go
@@ -3,6 +3,7 @@
 package keyring
 
 import (
+	"os"
 	"sort"
 	"testing"
 
@@ -21,6 +22,10 @@ import (
 //     and provides the Prompt interface using the go-libsecret library.
 
 func libSecretSetup(t *testing.T) (Keyring, func(t *testing.T)) {
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping testing in CI environment")
+	}
+
 	service, err := libsecret.NewService()
 	if err != nil {
 		t.Fatal(err)

--- a/libsecret_test.go
+++ b/libsecret_test.go
@@ -45,8 +45,8 @@ func TestLibSecretKeysWhenEmpty(t *testing.T) {
 	kr, _ := libSecretSetup(t)
 
 	_, err := kr.Keys()
-	if err != ErrCollectionNotFound {
-		t.Fatal("Expected keyring.ErrCollectionNotFound")
+	if err != ErrKeyNotFound {
+		t.Fatalf("Expected ErrKeyNotFound, got: %s", err)
 	}
 }
 
@@ -88,7 +88,7 @@ func TestLibSecretGetWhenEmpty(t *testing.T) {
 
 	_, err := kr.Get("llamas")
 	if err != ErrKeyNotFound {
-		t.Fatal("Expected ErrKeyNotFound")
+		t.Fatalf("Expected ErrKeyNotFound, got: %s", err)
 	}
 }
 
@@ -115,8 +115,8 @@ func TestLibSecretRemoveWhenEmpty(t *testing.T) {
 	kr, _ := libSecretSetup(t)
 
 	err := kr.Remove("no-such-key")
-	if err != ErrCollectionNotFound {
-		t.Fatal("Expected keyring.ErrCollectionNotFound")
+	if err != ErrKeyNotFound {
+		t.Fatalf("Expected ErrKeyNotFound, got: %s", err)
 	}
 }
 

--- a/libsecret_test.go
+++ b/libsecret_test.go
@@ -45,9 +45,8 @@ func TestLibSecretKeysWhenEmpty(t *testing.T) {
 	kr, _ := libSecretSetup(t)
 
 	_, err := kr.Keys()
-	// TODO: consider making Keys() return ErrNoSuchKey similar to when Get() is called before a keychain exists
-	if err == nil {
-		t.Fatal("expected keyring.secretsError")
+	if err != ErrCollectionNotFound {
+		t.Fatal("Expected keyring.ErrCollectionNotFound")
 	}
 }
 
@@ -112,9 +111,30 @@ func TestLibSecretGetWhenNotEmpty(t *testing.T) {
 	}
 }
 
-// func TestLibSecretRemoveWhenEmpty(t *testing.T) {
-// 	kr, _ := libSecretSetup(t)
+func TestLibSecretRemoveWhenEmpty(t *testing.T) {
+	kr, _ := libSecretSetup(t)
 
-// }
+	err := kr.Remove("no-such-key")
+	if err != ErrCollectionNotFound {
+		t.Fatal("Expected keyring.ErrCollectionNotFound")
+	}
+}
 
-// func TestLibSecretRemoveWhenNotEmpty(t *testing.T) {}
+func TestLibSecretRemoveWhenNotEmpty(t *testing.T) {
+	kr, teardown := libSecretSetup(t)
+	defer teardown(t)
+
+	item := Item{Key: "llamas", Data: []byte("llamas are great")}
+
+	if err := kr.Set(item); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := kr.Get("llamas"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := kr.Remove("llamas"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pass.go
+++ b/pass.go
@@ -52,6 +52,10 @@ func (k *passKeyring) pass(args ...string) (*exec.Cmd, error) {
 }
 
 func (k *passKeyring) Get(key string) (Item, error) {
+	if !k.itemExists(key) {
+		return Item{}, ErrKeyNotFound
+	}
+
 	name := filepath.Join(k.prefix, key)
 	cmd, err := k.pass("show", name)
 	if err != nil {
@@ -96,6 +100,10 @@ func (k *passKeyring) Set(i Item) error {
 }
 
 func (k *passKeyring) Remove(key string) error {
+	if !k.itemExists(key) {
+		return ErrKeyNotFound
+	}
+
 	name := filepath.Join(k.prefix, key)
 	cmd, err := k.pass("rm", "-f", name)
 	if err != nil {
@@ -110,6 +118,15 @@ func (k *passKeyring) Remove(key string) error {
 	return nil
 }
 
+func (k *passKeyring) itemExists(key string) bool {
+	var path = filepath.Join(k.dir, k.prefix, key+".gpg")
+	_, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return true
+}
+
 func (k *passKeyring) Keys() ([]string, error) {
 	var keys = []string{}
 	var path = filepath.Join(k.dir, k.prefix)
@@ -117,7 +134,7 @@ func (k *passKeyring) Keys() ([]string, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return keys, nil
+			return keys, ErrKeyNotFound
 		}
 		return keys, err
 	}
@@ -134,9 +151,10 @@ func (k *passKeyring) Keys() ([]string, error) {
 		if filepath.Ext(f.Name()) == ".gpg" {
 			name := filepath.Base(f.Name())
 			keys = append(keys, name[:len(name)-4])
-
 		}
 	}
-
+	if len(keys) == 0 {
+		return keys, ErrKeyNotFound
+	}
 	return keys, nil
 }

--- a/pass.go
+++ b/pass.go
@@ -134,7 +134,7 @@ func (k *passKeyring) Keys() ([]string, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return keys, ErrKeyNotFound
+			return keys, nil
 		}
 		return keys, err
 	}
@@ -152,9 +152,6 @@ func (k *passKeyring) Keys() ([]string, error) {
 			name := filepath.Base(f.Name())
 			keys = append(keys, name[:len(name)-4])
 		}
-	}
-	if len(keys) == 0 {
-		return keys, ErrKeyNotFound
 	}
 	return keys, nil
 }

--- a/pass_test.go
+++ b/pass_test.go
@@ -1,6 +1,7 @@
 package keyring
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -131,7 +132,17 @@ func TestPassKeyringKeysWhenNotEmpty(t *testing.T) {
 	}
 }
 
-func TestPassKeyringRemove(t *testing.T) {
+func TestPassKeyringRemoveWhenEmpty(t *testing.T) {
+	k, teardown := setup(t)
+	defer teardown(t)
+
+	err := k.Remove("no-such-key")
+	if err == nil {
+		t.Log("Expected error")
+	}
+}
+
+func TestPassKeyringRemoveWhenNotEmpty(t *testing.T) {
 	k, teardown := setup(t)
 	defer teardown(t)
 
@@ -152,5 +163,34 @@ func TestPassKeyringRemove(t *testing.T) {
 
 	if len(keys) != 0 {
 		t.Fatalf("Expected 0 keys, got %d", len(keys))
+	}
+}
+
+func TestPassKeyringGetWhenEmpty(t *testing.T) {
+	k, teardown := setup(t)
+	defer teardown(t)
+
+	_, err := k.Get("no-such-key")
+	if err == nil {
+		t.Log("Expected error")
+	}
+}
+
+func TestPassKeyringGetWhenNotEmpty(t *testing.T) {
+	k, teardown := setup(t)
+	defer teardown(t)
+
+	item := Item{Key: "llamas", Data: []byte("llamas are great")}
+
+	if err := k.Set(item); err != nil {
+		t.Fatal(err)
+	}
+
+	v1, err := k.Get(item.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(v1.Data, item.Data) {
+		t.Fatal("Expected item not returned")
 	}
 }

--- a/pass_test.go
+++ b/pass_test.go
@@ -88,9 +88,12 @@ func TestPassKeyringKeysWhenEmpty(t *testing.T) {
 	k, teardown := setup(t)
 	defer teardown(t)
 
-	_, err := k.Keys()
-	if err != ErrKeyNotFound {
-		t.Fatalf("expected ErrKeyNotFound, got: %v", err)
+	keys, err := k.Keys()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("Expected 0 keys, got %d", len(keys))
 	}
 }
 
@@ -153,8 +156,8 @@ func TestPassKeyringRemoveWhenNotEmpty(t *testing.T) {
 	}
 
 	keys, err := k.Keys()
-	if err != ErrKeyNotFound {
-		t.Fatalf("expected ErrKeyNotFound, got: %v", err)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	if len(keys) != 0 {

--- a/pass_test.go
+++ b/pass_test.go
@@ -88,13 +88,9 @@ func TestPassKeyringKeysWhenEmpty(t *testing.T) {
 	k, teardown := setup(t)
 	defer teardown(t)
 
-	keys, err := k.Keys()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(keys) != 0 {
-		t.Fatalf("Expected 0 keys, got %q", len(keys))
+	_, err := k.Keys()
+	if err != ErrKeyNotFound {
+		t.Fatalf("expected ErrKeyNotFound, got: %v", err)
 	}
 }
 
@@ -137,8 +133,8 @@ func TestPassKeyringRemoveWhenEmpty(t *testing.T) {
 	defer teardown(t)
 
 	err := k.Remove("no-such-key")
-	if err == nil {
-		t.Log("Expected error")
+	if err != ErrKeyNotFound {
+		t.Fatalf("expected ErrKeyNotFound, got: %v", err)
 	}
 }
 
@@ -157,8 +153,8 @@ func TestPassKeyringRemoveWhenNotEmpty(t *testing.T) {
 	}
 
 	keys, err := k.Keys()
-	if err != nil {
-		t.Fatal(err)
+	if err != ErrKeyNotFound {
+		t.Fatalf("expected ErrKeyNotFound, got: %v", err)
 	}
 
 	if len(keys) != 0 {
@@ -171,8 +167,8 @@ func TestPassKeyringGetWhenEmpty(t *testing.T) {
 	defer teardown(t)
 
 	_, err := k.Get("no-such-key")
-	if err == nil {
-		t.Log("Expected error")
+	if err != ErrKeyNotFound {
+		t.Fatalf("expected ErrKeyNotFound, got: %v", err)
 	}
 }
 

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,0 +1,44 @@
+vagrant
+=======
+
+This directory contains Vagrant images for use in development and testing.
+
+Using
+-----
+
+**Pre-Reqs:**
+
+1. Install vagrant
+2. Install vagrant plugins:
+
+```sh
+vagrant plugin install vagrant-vbguest
+vagrant plugin install vagrant-reload
+```
+
+**Launch**:
+
+```sh
+cd vagrant/fedora
+vagrant up
+```
+
+This will launch the fedora VM with a Gnome UI and Gnome Keyring installed.
+A full go environment will also be installed. The first `up` may take a while
+to install all the packages and reboot at least once. You may want to use
+`vagrant halt` instead of `destroy` to suspend the VM until you're done
+with dev/test.
+
+The root of the project will be mounted as a host folder to `/src`.
+
+Run tests from an SSH or GUI Terminal session in the fedora VM:
+
+```sh
+cd /src
+go test -v ./...
+```
+
+TODO
+----
+
+- [ ] A Windows Vagrant VM for testing wincred.go

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -6,6 +6,8 @@ This directory contains Vagrant images for use in development and testing.
 Using
 -----
 
+### Fedora (Gnome desktop)
+
 **Pre-Reqs:**
 
 1. Install vagrant
@@ -38,7 +40,26 @@ cd /src
 go test -v ./...
 ```
 
-TODO
-----
+### Windows 10
 
-- [ ] A Windows Vagrant VM for testing wincred.go
+**Pre-Reqs:**
+
+1. Install vagrant
+
+**Launch**:
+
+```sh
+cd vagrant/windows
+vagrant up
+```
+
+`git` and `go` will be installed via the chocolately package manager.
+
+A GUI will open up. Login and open cmd or powershell.
+
+The root of the project will be mounted to `C:\src`
+
+```sh
+cd C:\src
+go test -v .
+```

--- a/vagrant/fedora/Vagrantfile
+++ b/vagrant/fedora/Vagrantfile
@@ -1,0 +1,56 @@
+# required plugins:
+#
+#  vagrant plugin install vagrant-vbguest
+#  vagrant plugin install vagrant-reload
+#
+
+Vagrant.configure("2") do |config|
+  # https://app.vagrantup.com/generic/boxes/fedora29
+  config.vm.box = "generic/fedora29"
+  config.vm.box_version = "1.9.14"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.gui = true
+    vb.memory = 1024
+    vb.cpus = 2
+    vb.customize ["modifyvm", :id, "--vram", "128"]
+    vb.customize ["modifyvm", :id, "--accelerate3d", "off"]
+  end
+
+  # vagrant plugin install vagrant-vbguest
+  config.vbguest.auto_update = true
+
+  # install gnome + xorg
+  config.vm.provision "shell", inline: "sudo dnf group install -y gnome-desktop base-x"
+  config.vm.provision "shell", inline: "sudo systemctl set-default graphical.target"
+
+  # disable wayland, force Xorg. Wayland seems buggy and very slow in Vbox 6.0/fedora29
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo sed -i -e 's/#WaylandEnable=false/WaylandEnable=false/' \
+                -e 's/\\[daemon\\]/\\[daemon\\]\\nDefaultSession=gnome-xorg.desktop/' \
+                /etc/gdm/custom.conf
+SHELL
+
+  # disable super annoying packagekitd
+  config.vm.provision "shell", inline: "sudo systemctl disable packagekit"
+  config.vm.provision "shell", inline: "sudo systemctl stop    packagekit"
+
+  # gnome keyring
+  config.vm.provision "shell", inline: "sudo dnf install -y gnome-keyring seahorse"
+
+  # kwallet
+  config.vm.provision "shell", inline: "sudo dnf install -y kwalletmanager5"
+
+  # install latest golang
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo rpm --import https://mirror.go-repo.io/fedora/RPM-GPG-KEY-GO-REPO
+    curl -s https://mirror.go-repo.io/fedora/go-repo.repo | sudo tee /etc/yum.repos.d/go-repo.repo
+    sudo dnf install -y golang
+SHELL
+
+  # vagrant plugin install vagrant-reload
+  config.vm.provision :reload
+
+  # mount the project into /src
+  config.vm.synced_folder "../..", "/src"
+end

--- a/vagrant/windows/Vagrantfile
+++ b/vagrant/windows/Vagrantfile
@@ -1,0 +1,24 @@
+Vagrant.configure("2") do |config|
+  # https://app.vagrantup.com/StefanScherer/boxes/windows_10
+  config.vm.box = "StefanScherer/windows_10"
+  config.vm.box_version = "2019.05.22"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.gui = true
+    vb.memory = 2048
+    vb.cpus = 2
+    vb.customize ["modifyvm", :id, "--vram", "128"]
+    vb.customize ["modifyvm", :id, "--accelerate3d", "on"]
+  end
+
+  # install chocolately pkg manager
+  config.vm.provision "shell", privileged: true, inline: <<-SHELL
+  Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+SHELL
+
+  config.vm.provision "shell", inline: "choco install -y git"
+  config.vm.provision "shell", inline: "choco install -y golang"
+
+  # mount the project into c:\src
+  config.vm.synced_folder "../..", "/src"
+end

--- a/wincred.go
+++ b/wincred.go
@@ -85,6 +85,10 @@ func (k *windowsKeyring) Keys() ([]string, error) {
 		}
 	}
 
+	if len(results) == 0 {
+		return results, ErrKeyNotFound
+	}
+
 	return results, nil
 }
 

--- a/wincred.go
+++ b/wincred.go
@@ -49,6 +49,13 @@ func (k *windowsKeyring) Get(key string) (Item, error) {
 	return item, nil
 }
 
+// GetMetadata for pass returns an error indicating that it's unsupported
+// for this backend.
+// TODO: This is a stub. Look into whether pass would support metadata in a usable way for keyring.
+func (k *windowsKeyring) GetMetadata(_ string) (Metadata, error) {
+	return Metadata{}, ErrMetadataNeedsCredentials
+}
+
 func (k *windowsKeyring) Set(item Item) error {
 	cred := wincred.NewGenericCredential(k.credentialName(item.Key))
 	cred.CredentialBlob = item.Data

--- a/wincred.go
+++ b/wincred.go
@@ -85,10 +85,6 @@ func (k *windowsKeyring) Keys() ([]string, error) {
 		}
 	}
 
-	if len(results) == 0 {
-		return results, ErrKeyNotFound
-	}
-
 	return results, nil
 }
 

--- a/wincred_test.go
+++ b/wincred_test.go
@@ -73,6 +73,11 @@ func TestListingCredentialsWithWinCred(t *testing.T) {
 	if expected := []string{"test"}; !reflect.DeepEqual(keys, expected) {
 		t.Fatalf("Unexpected keys, got %#v, expected %#v", keys, expected)
 	}
+
+	err = kr.Remove("test")
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestWinCredGetWhenEmpty(t *testing.T) {
@@ -112,7 +117,7 @@ func TestWinCredKeysWhenEmpty(t *testing.T) {
 	}
 
 	_, err = kr.Keys()
-	if err != nil {
-		t.Fatal(err)
+	if err != keyring.ErrKeyNotFound {
+		t.Fatal("Expected ErrKeyNotFound")
 	}
 }

--- a/wincred_test.go
+++ b/wincred_test.go
@@ -116,8 +116,11 @@ func TestWinCredKeysWhenEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = kr.Keys()
-	if err != keyring.ErrKeyNotFound {
-		t.Fatal("Expected ErrKeyNotFound")
+	keys, err := kr.Keys()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("Expected 0 keys, got %d", len(keys))
 	}
 }

--- a/wincred_test.go
+++ b/wincred_test.go
@@ -74,3 +74,45 @@ func TestListingCredentialsWithWinCred(t *testing.T) {
 		t.Fatalf("Unexpected keys, got %#v, expected %#v", keys, expected)
 	}
 }
+
+func TestWinCredGetWhenEmpty(t *testing.T) {
+	kr, err := keyring.Open(keyring.Config{
+		AllowedBackends: []keyring.BackendType{keyring.WinCredBackend},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = kr.Get("llamas")
+	if err != keyring.ErrKeyNotFound {
+		t.Fatal("Expected ErrKeyNotFound")
+	}
+}
+
+func TestWinCredRemoveWhenEmpty(t *testing.T) {
+	kr, err := keyring.Open(keyring.Config{
+		AllowedBackends: []keyring.BackendType{keyring.WinCredBackend},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = kr.Remove("no-such-key")
+	if err != keyring.ErrKeyNotFound {
+		t.Fatal("Expected ErrKeyNotFound")
+	}
+}
+
+func TestWinCredKeysWhenEmpty(t *testing.T) {
+	kr, err := keyring.Open(keyring.Config{
+		AllowedBackends: []keyring.BackendType{keyring.WinCredBackend},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = kr.Keys()
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This PR includes several commits that came out of my attempt to address #45 

- adds a GetMetadata() stub to `pass.go` which was necessary to build or run tests on the package.
- adds a GetMetadata() stub to `wincred.go` which was necessary to build or run tests on the package.
- Added new `libsecret_test.go` to assert behavior of the `secret-service` backend (NOTE: these tests can't be run in CI or a headless environment right now because they require an app providing the 'Prompt' service on DBus. I left some notes about this and future directions in the comments.)
- adds tests to `wincred_test.go`, `pass_test.go`, and `keychain_test.go` to assert behavior or get/remove/keys when the backing store is empty.
- adds directory `vagrant/` which contains GUI VM's for fedora and windows10 to provide a way to dev/test on the libsecret and wincred backends.
- Finally, `libsecret.go` API behavior around Get/Remove/Keys has changed. Get() now returns `ErrKeyNotFound` just like the keychain and wincred backends. I also added a new public `ErrCollectionNotFound` that is returned by Remove() and Keys() instead of the previous private `secretsError`.

Current `master` branch behavior of all backends when each of the API calls are made with an empty backing store (ie: before the first call to `Set()` occurs:

backend   | get            | set | remove                         | keys
----------|----------------|-----|--------------------------------|-------------------------------
keychain  | ErrKeyNotFound | nil | gokeychain.ErrorNoSuchKeychain | gokeychain.ErrorNoSuchKeychain
libsecret | secretsError   | nil | secretsError                   | secretsError
wincred   | ErrKeyNotFound | nil | ErrKeyNotFound                 | nil
pass      | exec.ExitError | nil | exec.ExitError                 | nil

After change to `libsecret.go` in this PR. Changes are highlighted:

backend   | get                | set | remove                         | keys
----------|--------------------|-----|--------------------------------|-------------------------------
keychain  | ErrKeyNotFound     | nil | gokeychain.ErrorNoSuchKeychain | gokeychain.ErrorNoSuchKeychain
libsecret | **ErrKeyNotFound** | nil | **ErrCollectionNotFound**      | **ErrCollectionNotFound**
wincred   | ErrKeyNotFound     | nil | ErrKeyNotFound                 | nil
pass      | exec.ExitError     | nil | exec.ExitError                 | nil

I have not included any changes to `pass`, `kwallet`, or `file` in this PR.

This doesn't address the API inconsistencies in the `kwallet.go` backend. I could probably take a crack at that in another PR but in my own application I'm considering not even supporting KWallet. I'm not a Linux desktop user and don't know the details behind it but it sounds like the project might be orphaned? And might have a replacement in KSecretsManager (or some such) that speaks the DBus Secrets API protocol like Gnome Keyring. If that's true then KDE users should be serviceable via the `libsecret.go`/"secret-service" backend.
