### PR TITLE
#47 - Fix error: missing GetMetadata method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
   - osx
 addons:
   homebrew:
+    update: True
     packages:
     - gnupg
     - pass

--- a/pass.go
+++ b/pass.go
@@ -70,7 +70,7 @@ func (k *passKeyring) Get(key string) (Item, error) {
 }
 
 func (k *passKeyring) GetMetadata(key string) (Metadata, error) {
-    return Metadata{}, nil
+	return Metadata{}, nil
 }
 
 func (k *passKeyring) Set(i Item) error {

--- a/pass.go
+++ b/pass.go
@@ -69,6 +69,10 @@ func (k *passKeyring) Get(key string) (Item, error) {
 	return decoded, err
 }
 
+func (k *passKeyring) GetMetadata(key string) (Metadata, error) {
+    return Metadata{}, nil
+}
+
 func (k *passKeyring) Set(i Item) error {
 	bytes, err := json.Marshal(i)
 	if err != nil {


### PR DESCRIPTION
Fixes error:

```
../../../../1.12.5/src/github.com/99designs/keyring/pass.go:34:3: cannot
use pass (type *passKeyring) as type Keyring in return argument:
        *passKeyring does not implement Keyring (missing GetMetadata method)
```

This will get it to compile. I'm sure it should do more though.