### PR TITLE
Use new kwallet5 dbus interface

### DIFF
--- a/kwallet.go
+++ b/kwallet.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	dbusServiceName = "org.kde.kwalletd"
-	dbusPath        = "/modules/kwalletd"
+	dbusServiceName = "org.kde.kwalletd5"
+	dbusPath        = "/modules/kwalletd5"
 )
 
 func init() {


### PR DESCRIPTION
Fixes #51

Use the new `org.kde.kwalletd5` interface for KWallet 5.61, the old interface is deprecated, please check the linked issue.
I also built `aws-vault` from this commit and it now works.