### PR TITLE
Fix deprecated TrustedApplicationAccess on Macos Catalina

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,9 +11,6 @@ type Config struct {
 	// MacOSKeychainNameKeychainName is the name of the macOS keychain that is used
 	KeychainName string
 
-	// KeychainTrustApplication is whether the calling application should be trusted by default by items
-	KeychainTrustApplication bool
-
 	// KeychainSynchronizable is whether the item can be synchronized to iCloud
 	KeychainSynchronizable bool
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dvsekhvalnov/jose2go v0.0.0-20180829124132-7f401d37b68a
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c
-	github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d
+	github.com/keybase/go-keychain v0.0.0-20191220220820-f65a47cbe0b1
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/stretchr/objx v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
-github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d h1:Z+RDyXzjKE0i2sTjZ/b1uxiGtPhFy34Ou/Tk0qwN0kM=
-github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d/go.mod h1:JJNrCn9otv/2QP4D7SMJBgaleKpOf66PnW6F5WGNRIc=
+github.com/keybase/go-keychain v0.0.0-20191220220820-f65a47cbe0b1 h1:Lk38J60jgB05LTkSEElUXe49VEzWMNrPyPFf2vhKM1k=
+github.com/keybase/go-keychain v0.0.0-20191220220820-f65a47cbe0b1/go.mod h1:JJNrCn9otv/2QP4D7SMJBgaleKpOf66PnW6F5WGNRIc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/keychain_test.go
+++ b/keychain_test.go
@@ -19,7 +19,6 @@ func TestOSXKeychainKeyringSet(t *testing.T) {
 		path:         path,
 		passwordFunc: fixedStringPrompt("test password"),
 		service:      "test",
-		isTrusted:    true,
 	}
 
 	item := Item{
@@ -59,7 +58,6 @@ func TestOSXKeychainKeyringOverwrite(t *testing.T) {
 		path:         path,
 		passwordFunc: fixedStringPrompt("test password"),
 		service:      "test",
-		isTrusted:    true,
 	}
 
 	item1 := Item{
@@ -111,7 +109,6 @@ func TestOSXKeychainKeyringListKeysWhenEmpty(t *testing.T) {
 		path:         path,
 		service:      "test",
 		passwordFunc: fixedStringPrompt("test password"),
-		isTrusted:    true,
 	}
 
 	keys, err := k.Keys()
@@ -131,7 +128,6 @@ func TestOSXKeychainKeyringListKeysWhenNotEmpty(t *testing.T) {
 		path:         path,
 		service:      "test",
 		passwordFunc: fixedStringPrompt("test password"),
-		isTrusted:    true,
 	}
 
 	keys := []string{"key1", "key2", "key3"}
@@ -177,7 +173,6 @@ func TestOSXKeychainGetKeyWhenEmpty(t *testing.T) {
 		path:         path,
 		passwordFunc: fixedStringPrompt("test password"),
 		service:      "test",
-		isTrusted:    true,
 	}
 
 	_, err := k.Get("no-such-key")
@@ -194,7 +189,6 @@ func TestOSXKeychainGetKeyWhenNotEmpty(t *testing.T) {
 		path:         path,
 		passwordFunc: fixedStringPrompt("test password"),
 		service:      "test",
-		isTrusted:    true,
 	}
 	item := Item{
 		Key:         "llamas",
@@ -224,7 +218,6 @@ func TestOSXKeychainRemoveKeyWhenEmpty(t *testing.T) {
 		path:         path,
 		passwordFunc: fixedStringPrompt("test password"),
 		service:      "test",
-		isTrusted:    true,
 	}
 
 	err := k.Remove("no-such-key")
@@ -241,7 +234,6 @@ func TestOSXKeychainRemoveKeyWhenNotEmpty(t *testing.T) {
 		path:         path,
 		passwordFunc: fixedStringPrompt("test password"),
 		service:      "test",
-		isTrusted:    true,
 	}
 	item := Item{
 		Key:         "llamas",


### PR DESCRIPTION
Updated keybase/go-keychain dependency to remove deprecation warnings about TrustedApplicationAccess on Macos Catalina

resolves #56