### PR TITLE
libsecret: Keys() unlocks collection first

### DIFF
--- a/cmd/keyring/main.go
+++ b/cmd/keyring/main.go
@@ -17,7 +17,7 @@ func main() {
 	listBackends := flag.Bool("list-backends", false, "Whether to list backends")
 
 	// actions to take
-	actionListKeys := flag.Bool("list-keys", false, "Whether to list backends")
+	actionListKeys := flag.Bool("list-keys", false, "Whether to list keys")
 	actionSetValue := flag.String("set", "", "The value to set")
 
 	// keychain


### PR DESCRIPTION
Fixes https://github.com/99designs/aws-vault/issues/513

This patch makes `secretsKeyring.Keys()` unlock a locked collection before getting its items and their labels. Otherwise, it returns a list of empty strings.

I spent quite a while trying to write a test for it, but testing over live D-Bus with locking and caching(?) proved beyond me. Instead I've verified it from ./cmd/keyring:

```shell
# build without this patch
go build ./cmd/keyring

# setting keys leaves the collection unlocked
./keyring -service keyringtest -key one -set hello
./keyring -service keyringtest -key two -set world

# Keys() works when the collection is unlocked
./keyring -service keyringtest -list-keys
# two
# one

# Reloading the keyring daemon locks the collections
gnome-keyring-daemon -r -d
# ** Message: 15:11:41.910: Replacing daemon, using directory: /run/user/1000/keyring
# GNOME_KEYRING_CONTROL=/run/user/1000/keyring
# SSH_AUTH_SOCK=/run/user/1000/keyring/ssh

# Keys() returns empty strings
./keyring -service keyringtest -list-keys
#
#

# apply this patch...
go build ./cmd/keyring

# Keys() returns actual strings
./keyring -service keyringtest -list-keys
# one
# two
```