### PR TITLE
Return an empty Item for file metadata to avoid nil pointer

### DIFF
--- a/file.go
+++ b/file.go
@@ -120,13 +120,14 @@ func (k *fileKeyring) GetMetadata(key string) (Metadata, error) {
 	}
 
 	// For the File provider, all internal data is encrypted, not just the
-	// credentials.  Thus we only have the timestamps.  Return a nil *Item.
+	// credentials.  Thus we only have the timestamps.  Return an empty *Item.
 	//
 	// If we want to change this ... how portable are extended file attributes
 	// these days?  Would it break user expectations of the security model to
 	// leak data into those?  I'm hesitant to do so.
 
 	return Metadata{
+		Item:             &Item{},
 		ModificationTime: stat.ModTime(),
 	}, nil
 }


### PR DESCRIPTION
When running the v6 version of `aws-vault`, using the file backend I'm seeing a nil pointer when `aws-vault` tries to get the metadata of the item in the keychain:

```
> aws-vault login profile-a

15:36:28 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x9a8d1f]

goroutine 1 [running]:
github.com/99designs/aws-vault/v5/vault.(*SessionKeyring).GetMetadata(0xc0001279c0, 0xc00014e4d0, 0x1b, 0xc000132df0, 0xe, 0xc000136ea0, 0x27, 0x0, 0x0, 0x0, ...)
        github.com/99designs/aws-vault/v5/vault/sessionkeyring.go:172 +0x1af
github.com/99designs/aws-vault/v5/vault.(*SessionKeyring).GarbageCollectOnce(0xc0001279c0, 0xc0001223b8, 0x1, 0x1)
        github.com/99designs/aws-vault/v5/vault/sessionkeyring.go:243 +0x296
github.com/99designs/aws-vault/v5/vault.(*SessionKeyring).Get(0xc0001279c0, 0xb89a02, 0x1b, 0x7ffc7c3a41a6, 0xe, 0xc000136990, 0x27, 0x0, 0x0, 0x0)
        github.com/99designs/aws-vault/v5/vault/sessionkeyring.go:103 +0x5a
github.com/99designs/aws-vault/v5/vault.(*CachedSessionProvider).Retrieve(0xc000153570, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x10, ...)
        github.com/99designs/aws-vault/v5/vault/cachedsessionprovider.go:24 +0xb4
github.com/aws/aws-sdk-go/aws/credentials.(*Credentials).Get(0xc0001535e0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        github.com/aws/aws-sdk-go@v1.25.37/aws/credentials/credentials.go:241 +0x174
github.com/99designs/aws-vault/v5/cli.LoginCommand(0x7ffc7c3a41a6, 0xe, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        github.com/99designs/aws-vault/v5/cli/login.go:104 +0x189
github.com/99designs/aws-vault/v5/cli.ConfigureLoginCommand.func1(0xc00016e000, 0x40a5b3, 0xacec20)
        github.com/99designs/aws-vault/v5/cli/login.go:75 +0x1af
gopkg.in/alecthomas/kingpin%2ev2.(*actionMixin).applyActions(0xc00016a3d8, 0xc00016e000, 0x0, 0x0)
        gopkg.in/alecthomas/kingpin.v2@v2.2.6/actions.go:28 +0x6d
gopkg.in/alecthomas/kingpin%2ev2.(*Application).applyActions(0xc000166690, 0xc00016e000, 0x0, 0x0)
        gopkg.in/alecthomas/kingpin.v2@v2.2.6/app.go:557 +0xdc
gopkg.in/alecthomas/kingpin%2ev2.(*Application).execute(0xc000166690, 0xc00016e000, 0xc000124530, 0x1, 0x1, 0x0, 0x0, 0x0, 0xae11a0)
        gopkg.in/alecthomas/kingpin.v2@v2.2.6/app.go:390 +0x8f
gopkg.in/alecthomas/kingpin%2ev2.(*Application).Parse(0xc000166690, 0xc000188070, 0x2, 0x2, 0xc000166690, 0x405aff, 0xc000182058, 0x0)
        gopkg.in/alecthomas/kingpin.v2@v2.2.6/app.go:222 +0x1fe
main.main()
        github.com/99designs/aws-vault/v5/main.go:26 +0x184
```

On further investigation at line 172, there is:
```
matches := regexp.MustCompile(`\(expires (.+)\)$`).FindStringSubmatch(item.Label)
```
This throws a nil pointer due to the inherited `Item` being nil. This change just returns an empty `Item` object, rather than returning nil.

On testing this with `aws-vault` and the forked version of this library, the file backend now works. 