### PR TITLE
Added support for LastPass

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Currently Keyring supports the following backends
   * [Secret Service](https://github.com/99designs/aws-vault/pull/98)
   * [KDE Wallet](https://github.com/99designs/aws-vault/pull/27)
   * [Encrypted File](https://github.com/99designs/aws-vault/pull/63)
+  * [LastPass](https://github.com/99designs/aws-vault/pull/597)
+     * Requires [lastpass-cli](https://github.com/lastpass/lastpass-cli)
 
 ## Installing
 

--- a/config.go
+++ b/config.go
@@ -49,4 +49,10 @@ type Config struct {
 
 	// WinCredPrefix is a string prefix to prepend to the key name
 	WinCredPrefix string
+
+	//Last Pass executable
+	LastPassCmd string
+
+	//Folder in LastPass to hold keys
+	LastPassFolder string
 }

--- a/keyring.go
+++ b/keyring.go
@@ -21,6 +21,7 @@ const (
 	WinCredBackend       BackendType = "wincred"
 	FileBackend          BackendType = "file"
 	PassBackend          BackendType = "pass"
+	LastPassBackend      BackendType = "lastpass"
 )
 
 // This order makes sure the OS-specific backends
@@ -36,6 +37,7 @@ var backendOrder = []BackendType{
 	// General
 	PassBackend,
 	FileBackend,
+	LastPassBackend,
 }
 
 var supportedBackends = map[BackendType]opener{}

--- a/lastpass.go
+++ b/lastpass.go
@@ -1,0 +1,125 @@
+package keyring
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type lastPassKeyring struct {
+	lpasscmd string
+	folder   string
+}
+
+func init() {
+	supportedBackends[LastPassBackend] = opener(func(cfg Config) (Keyring, error) {
+		lpass := &lastPassKeyring{
+			lpasscmd: cfg.LastPassCmd,
+			folder:   cfg.LastPassFolder,
+		}
+
+		if cfg.LastPassCmd == "" {
+			lpass.lpasscmd = "lpass"
+		}
+
+		if cfg.LastPassFolder == "" {
+			lpass.folder = "aws-vault"
+		}
+
+		_, err := exec.LookPath(lpass.lpasscmd)
+		if err != nil {
+			return nil, fmt.Errorf("The %s program is not available", lpass.lpasscmd)
+		}
+
+		return lpass, nil
+	})
+}
+
+func (k *lastPassKeyring) lpass(args ...string) (*exec.Cmd, error) {
+	cmd := exec.Command(k.lpasscmd, args...)
+
+	cmd.Stderr = os.Stderr
+
+	return cmd, nil
+}
+
+func (k *lastPassKeyring) Get(key string) (Item, error) {
+	name := fmt.Sprintf("%s/%s", k.folder, key)
+	cmd, err := k.lpass("show", "--sync=now", "--notes", name)
+
+	if err != nil {
+		return Item{}, err
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		return Item{}, err
+	}
+
+	var decoded Item
+	err = json.Unmarshal(output, &decoded)
+
+	return decoded, err
+}
+
+func (k *lastPassKeyring) GetMetadata(key string) (Metadata, error) {
+	return Metadata{}, nil
+}
+
+func (k *lastPassKeyring) Set(i Item) error {
+	bytes, err := json.Marshal(i)
+	if err != nil {
+		return err
+	}
+
+	name := fmt.Sprintf("%s/%s", k.folder, i.Key)
+	cmd, err := k.lpass("edit", "--sync=now", "--notes", "--non-interactive", name)
+	if err != nil {
+		return err
+	}
+
+	cmd.Stdin = strings.NewReader(string(bytes))
+
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (k *lastPassKeyring) Remove(key string) error {
+	name := filepath.Join(k.folder, key)
+	cmd, err := k.lpass("rm", "--sync=now", name)
+	if err != nil {
+		return err
+	}
+
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (k *lastPassKeyring) Keys() ([]string, error) {
+	var keys = []string{}
+
+	cmd, err := k.lpass("ls", "--sync=now", "--format=%an", "--color=never", k.folder)
+	if err != nil {
+		return keys, err
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		return keys, err
+	}
+
+	keys = strings.Split(string(output), "\n")
+
+	return keys, nil
+}


### PR DESCRIPTION
Resolves #55 

~~This utilizes [lastpass-cli](https://github.com/lastpass/lastpass-cli) to interact with the LastPass api.~~

~~Future enhancement may be to use [lastpass-go](https://github.com/ansd/lastpass-go) instead. This approach would require management of the LastPass session information which I felt was better left to lastpass-cli.~~

After using lastpass-cli as the backend it turns out to be pretty clunky if you try to use aws-vault in a gui app. I am going to rework this PR to use the lastpass-go library instead.