### PR TITLE
fix: fix detect of ErrKeyNotFound error on non-english windows system

### DIFF
--- a/wincred.go
+++ b/wincred.go
@@ -4,9 +4,13 @@ package keyring
 
 import (
 	"strings"
+	"syscall"
 
 	"github.com/danieljoos/wincred"
 )
+
+// ERROR_NOT_FOUND from https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--1000-1299-
+const elementNotFoundError = syscall.Errno(1168)
 
 type windowsKeyring struct {
 	name   string
@@ -35,7 +39,7 @@ func init() {
 func (k *windowsKeyring) Get(key string) (Item, error) {
 	cred, err := wincred.GetGenericCredential(k.credentialName(key))
 	if err != nil {
-		if err.Error() == "Element not found." {
+		if err == elementNotFoundError {
 			return Item{}, ErrKeyNotFound
 		}
 		return Item{}, err
@@ -65,7 +69,7 @@ func (k *windowsKeyring) Set(item Item) error {
 func (k *windowsKeyring) Remove(key string) error {
 	cred, err := wincred.GetGenericCredential(k.credentialName(key))
 	if err != nil {
-		if err.Error() == "Element not found." {
+		if err == elementNotFoundError {
 			return ErrKeyNotFound
 		}
 		return err


### PR DESCRIPTION
On german OS error looks like "Element nicht gefunden.", so comparison
```
		if err.Error() == "Element not found." {
```
is false. I fixed code to use localized system message.
