### PR TITLE
Add in memory keyring.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant
+.idea

--- a/examples/example.go
+++ b/examples/example.go
@@ -1,0 +1,23 @@
+package examples
+
+import (
+	"github.com/99designs/keyring"
+	"log"
+)
+
+// ExampleOpen is an example of how you would create a new keyring and how you would
+// retrieve data from it.
+func ExampleOpen() {
+	// Use the best keyring implementation for your operating system
+	kr, err := keyring.Open(keyring.Config{
+		ServiceName: "my-service",
+	})
+
+	v, err := kr.Get("llamas")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("llamas was %v", v)
+}
+

--- a/keyring.go
+++ b/keyring.go
@@ -4,6 +4,7 @@
 package keyring
 
 import (
+	"bytes"
 	"errors"
 	"log"
 	"time"
@@ -21,6 +22,7 @@ const (
 	WinCredBackend       BackendType = "wincred"
 	FileBackend          BackendType = "file"
 	PassBackend          BackendType = "pass"
+	MemoryBackend BackendType = "memory"
 )
 
 // This order makes sure the OS-specific backends
@@ -36,6 +38,7 @@ var backendOrder = []BackendType{
 	// General
 	PassBackend,
 	FileBackend,
+	MemoryBackend,
 }
 
 var supportedBackends = map[BackendType]opener{}
@@ -83,6 +86,17 @@ type Item struct {
 	// Backend specific config
 	KeychainNotTrustApplication bool
 	KeychainNotSynchronizable   bool
+}
+
+// Equals will return true if the current item is equal to the supplied item.
+func (i Item) Equals(other Item) bool {
+
+	return i.Key == other.Key &&
+		bytes.Equal(i.Data, other.Data) &&
+		i.Label == other.Label &&
+		i.Description == other.Description &&
+		i.KeychainNotTrustApplication == other.KeychainNotTrustApplication &&
+		i.KeychainNotSynchronizable == other.KeychainNotSynchronizable
 }
 
 // Metadata is information about a thing stored on the keyring; retrieving

--- a/keyring_test.go
+++ b/keyring_test.go
@@ -1,21 +1,64 @@
-package keyring_test
+package keyring
 
-import (
-	"log"
+import "testing"
 
-	"github.com/99designs/keyring"
-)
-
-func ExampleOpen() {
-	// Use the best keyring implementation for your operating system
-	kr, err := keyring.Open(keyring.Config{
-		ServiceName: "my-service",
-	})
-
-	v, err := kr.Get("llamas")
-	if err != nil {
-		log.Fatal(err)
+func TestItemsEqual(t *testing.T) {
+	i := Item{
+		Key: "key",
+		Data: []byte("data"),
+		Label: "label",
+		Description: "description",
+		KeychainNotTrustApplication: false,
+		KeychainNotSynchronizable: false,
 	}
 
-	log.Printf("llamas was %v", v)
+	// We're basically going to create copies of i and make sure each field difference generates a false return value
+	// from Equals.
+
+	// First, make sure identity is true.
+	o := i
+	if !i.Equals(o) {
+		t.Fatalf("identity case should result in true")
+	}
+
+	// Test key differences
+	o.Key = "something else"
+	if i.Equals(o) {
+		t.Fatalf("key difference should result in false")
+	}
+
+	// Test key differences
+	o = i
+	o.Data = []byte("something else")
+	if i.Equals(o) {
+		t.Fatalf("data difference should result in false")
+	}
+
+	// Test label differences
+	o = i
+	o.Label = "something else"
+	if i.Equals(o) {
+		t.Fatalf("label difference should result in false")
+	}
+
+	// Test description differences
+	o = i
+	o.Description = "something else"
+	if i.Equals(o) {
+		t.Fatalf("description difference should result in false")
+	}
+
+	// Test KeychainNotTrustApplication differences
+	o = i
+	o.KeychainNotTrustApplication = true
+	if i.Equals(o) {
+		t.Fatalf("KeyChainNotTrustApplication difference should result in false")
+	}
+
+	// Test KeychainNotSynchronizable differences
+	o = i
+	o.KeychainNotSynchronizable = true
+	if i.Equals(o) {
+		t.Fatalf("KeyChainNotSynchronizable difference should result in false")
+	}
 }

--- a/kwallet.go
+++ b/kwallet.go
@@ -107,7 +107,7 @@ func (k *kwalletKeyring) Get(key string) (Item, error) {
 // found in docs for methods to use to retrieve metadata without needing unlock
 // credentials.
 func (k *kwalletKeyring) GetMetadata(_ string) (Metadata, error) {
-	return Metadata{}, ErrMetadataNeedsCredentials
+	return Metadata{}, ErrNoAvailImpl
 }
 
 func (k *kwalletKeyring) Set(item Item) error {

--- a/memory.go
+++ b/memory.go
@@ -1,0 +1,71 @@
+package keyring
+
+import (
+	"sync"
+)
+
+func init() {
+	supportedBackends[MemoryBackend] = opener(func(cfg Config) (Keyring, error) {
+		memory := newMemoryKeyring()
+
+		return memory, nil
+	})
+}
+
+type memoryKeyring struct {
+	mutex sync.RWMutex
+	mapStore map[string]Item
+}
+
+func newMemoryKeyring() *memoryKeyring {
+	return &memoryKeyring{
+		mutex: sync.RWMutex{},
+		mapStore: map[string]Item{},
+	}
+}
+
+func (k *memoryKeyring) Get(key string) (Item, error) {
+	k.mutex.RLock()
+	defer k.mutex.RUnlock()
+
+	if item, ok := k.mapStore[key]; !ok {
+		return Item{}, ErrKeyNotFound
+	} else {
+		return item, nil
+	}
+}
+
+// GetMetadata for memory returns an error indicating that it's unsupported
+// for this backend.
+//
+// It doesn't really apply to the memory backend, as it's a simple wrapper around a map.
+func (k *memoryKeyring) GetMetadata(_ string) (Metadata, error) {
+	return Metadata{}, ErrNoAvailImpl
+}
+
+func (k *memoryKeyring) Set(item Item) error {
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
+
+	k.mapStore[item.Key] = item
+	return nil
+}
+
+func (k *memoryKeyring) Remove(key string) error {
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
+
+	delete(k.mapStore, key)
+	return nil
+}
+
+func (k *memoryKeyring) Keys() ([]string, error) {
+	k.mutex.RLock()
+	defer k.mutex.RUnlock()
+
+	keys := []string{}
+	for k := range k.mapStore {
+		keys = append(keys, k)
+	}
+	return keys, nil
+}

--- a/memory_test.go
+++ b/memory_test.go
@@ -1,0 +1,89 @@
+package keyring
+
+import "testing"
+
+func TestSetAndGets(t *testing.T) {
+	k := newMemoryKeyring()
+
+	// Set a few items and try to retrieve them
+	items := []Item{
+		makeItem("key1", "data1", "label1", "description1"),
+		makeItem("key2", "data2", "label2", "description2"),
+		makeItem("key3", "data3", "label3", "description3"),
+		makeItem("key4", "data4", "label4", "description4"),
+	}
+
+	for _, item := range items {
+		k.Set(item)
+	}
+
+	for _, item := range items {
+		getItem, _ := k.Get(item.Key)
+
+		if !item.Equals(getItem) {
+			t.Fatalf("%s is not equal to its version from the store", item.Key)
+		}
+	}
+
+	if _, err := k.Get("non-existent key"); err != ErrKeyNotFound {
+		t.Fatalf("error for non-existent key should have been key not found, was: %v", err)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	k := newMemoryKeyring()
+
+	item := makeItem("key1", "data1", "label1", "description1")
+
+	k.Set(item)
+
+	if _, err := k.Get(item.Key); err != nil {
+		t.Fatalf("unable to find stored item")
+	}
+
+	k.Remove(item.Key)
+
+	if _, err := k.Get(item.Key); err == nil {
+		t.Fatalf("after removal, should not have been able to find item")
+	}
+}
+
+func TestKeys(t *testing.T) {
+	k := newMemoryKeyring()
+
+	items := []Item{
+		makeItem("key1", "data1", "label1", "description1"),
+		makeItem("key2", "data2", "label2", "description2"),
+		makeItem("key3", "data3", "label3", "description3"),
+		makeItem("key4", "data4", "label4", "description4"),
+	}
+
+	for _, item := range items {
+		k.Set(item)
+	}
+
+	keys, _ := k.Keys()
+	for _, item := range items {
+		foundKey := false
+
+		for _, key := range keys {
+			if item.Key == key	 {
+				foundKey = true
+				break
+			}
+		}
+
+		if !foundKey {
+			t.Errorf("unable to find key %s", item.Key)
+		}
+	}
+}
+
+func makeItem(key, data, label, description string) Item {
+	return Item{
+		Key: key,
+		Data: []byte(data),
+		Label: label,
+		Description: description,
+	}
+}


### PR DESCRIPTION
An in-memory only keyring has been added. This will be useful for us because
we have command line tools that we want to store longer term state in
something like the OSX keychain, but later we may wish to automate the utility
in a more transient, ephemeral way. In that case, the memory store will store
the data for the duration of the run and recreate them on subsequent runs.

I've additionally refactored slightly and added in a test for an Item.Equals
function.

Note: I've tested this against vagrant and using the CLI, but it's not particularly useful outside of use as a library.