### PR TITLE
Expand pass dir path

### DIFF
--- a/pass.go
+++ b/pass.go
@@ -24,6 +24,15 @@ func init() {
 		}
 		if cfg.PassDir == "" {
 			pass.dir = filepath.Join(os.Getenv("HOME"), ".password-store")
+		} else if strings.HasPrefix(pass.dir, "~") {
+			if len(pass.dir) > 1 && pass.dir[1] != '/' {
+				return nil, fmt.Errorf("Cannot expand path: %s", pass.dir)
+			}
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return nil, err
+			}
+			pass.dir = filepath.Join(home, pass.dir[1:])
 		}
 
 		// fail if the pass program is not available


### PR DESCRIPTION
While you can avoid using `--opt=value` format to ensure `~` gets expanded by the shell, it was irritating enough for me to contribute this small change.