### PR TITLE
fix(kwallet): empty wallet key query

### DIFF
--- a/kwallet.go
+++ b/kwallet.go
@@ -90,6 +90,10 @@ func (k *kwalletKeyring) Get(key string) (Item, error) {
 	if err != nil {
 		return Item{}, err
 	}
+	if len(data) == 0 {
+		return Item{}, ErrKeyNotFound
+	}
+
 
 	item := Item{}
 	err = json.Unmarshal(data, &item)


### PR DESCRIPTION
When querying a key in an empty kwallet wallet, we receive the following error:
```
Error: unexpected end of JSON input
```
This is because the `k.wallet.ReadEntry` returns empty bytes and no error. Hence we should handle a case for empty bytes.

Reference: https://github.com/cosmos/cosmos-sdk/issues/9562