### PR TITLE
Create a tempdir by ioutil.TempDir instead of t.TempDir

### DIFF
--- a/pass_test.go
+++ b/pass_test.go
@@ -219,8 +219,14 @@ func TestPassKeyringKeysWithSymlink(t *testing.T) {
 		}
 	}
 
-	s := filepath.Join(t.TempDir(), "newsymlink")
-	err := os.Symlink(k.dir, s)
+	// Create a symlink named "newsymlink" in a new temp dir for this test.
+	tmpdir, err := ioutil.TempDir("/tmp", "keyring-pass-test-symlink-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+	s := filepath.Join(tmpdir, "newsymlink")
+	err = os.Symlink(k.dir, s)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
There seems to be [a failing test](https://github.com/99designs/keyring/runs/3911517221?check_suite_focus=true) due to missing API on 1.14 (t.TempDir, which was [added on 1.15](https://pkg.go.dev/testing#B.TempDir)).
This PR fixes it by making a temp dir by ioutil.TempDir().