### PR TITLE
go.mod: use forked go-keychain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/99designs/keyring
 go 1.14
 
 require (
+	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4
 	github.com/danieljoos/wincred v1.0.2
 	github.com/dvsekhvalnov/jose2go v0.0.0-20200901110807-248326c1351b
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c
-	github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mtibben/percent v0.2.1
 	github.com/stretchr/objx v0.3.0 // indirect
@@ -17,5 +17,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
-
-replace github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4

--- a/keychain.go
+++ b/keychain.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 
-	gokeychain "github.com/keybase/go-keychain"
+	gokeychain "github.com/99designs/go-keychain"
 )
 
 type keychain struct {


### PR DESCRIPTION
Fixes #94
I think this also fixes #93 

This updates the go modules (go.mod) to directly use the forked 99designs/go-keychain repository, instead of requiring keybase/go-keychain and then using the replace directive.  The reasoning for this is because the replace directive does not propagate to projects which depend on the go-keychain project.  This means other projects which depend on the go-keychain project still need to add their own replace directive.  Removing the replace directive from this project means that consumers will automatically get the forked 99designs/go-keychain indirect dependency.

The only case where I see this possibly causing a problem would be a project which depends on 99designs/keyring and also depends on another project which depends on the upstream keybase/go-keychain.  But even in that case, I believe go would just treat them as two separate packages and just include them both.