### PR TITLE
update go version used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17
       - run: sudo apt-get install pass gnome-keyring dbus-x11
       - uses: actions/checkout@v1
       - run: go test -race ./...
@@ -17,9 +17,9 @@ jobs:
   mac:
     runs-on: macOS-latest
     steps:
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17
       - run: brew install pass gnupg
       - uses: actions/checkout@v1
       - run: go test -race ./...
@@ -28,8 +28,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17
       - uses: actions/checkout@v1
       - run: diff -u <(echo -n) <(gofmt -s -d .)


### PR DESCRIPTION
This fixes a CI test failure which is caused by using testing TempDir() function
which was added in go 1.15.

See also #95 and #96 