### PR TITLE
Return ErrKeyNotFound when removing missing keychain items

### DIFF
--- a/keychain.go
+++ b/keychain.go
@@ -227,7 +227,13 @@ func (k *keychain) Remove(key string) error {
 	}
 
 	debugf("Removing keychain item service=%q, account=%q, keychain %q", k.service, key, k.path)
-	return gokeychain.DeleteItem(item)
+	err := gokeychain.DeleteItem(item)
+	if err == gokeychain.ErrorItemNotFound {
+		return ErrKeyNotFound
+	}
+
+	return err
+
 }
 
 func (k *keychain) Keys() ([]string, error) {


### PR DESCRIPTION
The keychain `Remove` implementation returns `gokeychain.ErrorItemNotFound` instead of `ErrKeyNotFound` when the item is not found