### PR TITLE
Fix nil pointer access

### DIFF
--- a/file.go
+++ b/file.go
@@ -45,7 +45,7 @@ func (k *fileKeyring) resolveDir() (string, error) {
 	stat, err := os.Stat(dir)
 	if os.IsNotExist(err) {
 		err = os.MkdirAll(dir, 0700)
-	} else if err != nil && stat !=nil && !stat.IsDir() {
+	} else if err != nil && stat != nil && !stat.IsDir() {
 		err = fmt.Errorf("%s is a file, not a directory", dir)
 	}
 

--- a/file.go
+++ b/file.go
@@ -45,7 +45,7 @@ func (k *fileKeyring) resolveDir() (string, error) {
 	stat, err := os.Stat(dir)
 	if os.IsNotExist(err) {
 		err = os.MkdirAll(dir, 0700)
-	} else if err != nil && !stat.IsDir() {
+	} else if err != nil && stat !=nil && !stat.IsDir() {
 		err = fmt.Errorf("%s is a file, not a directory", dir)
 	}
 


### PR DESCRIPTION
Fix this issue: 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x5b3310]

goroutine 1 [running]:
github.com/99designs/keyring.(*fileKeyring).resolveDir(0x7fa61e988400?)
        /Users/pfautre/Library/Go/pkg/mod/github.com/99designs/keyring@v1.2.1/file.go:48 +0x90
github.com/99designs/keyring.(*fileKeyring).Keys(0xc000280020?)
        /Users/pfautre/Library/Go/pkg/mod/github.com/99designs/keyring@v1.2.1/file.go:169 +0x2b
main.main()
```