### PR TITLE
Catch keychain's errSecUserCanceled 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: golangci-lint
-on: push
+on: pull_request
 jobs:
   golangci:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Continuous Integration
-on: push
+on: pull_request
 jobs:
   linux:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant
+.idea

--- a/keyring.go
+++ b/keyring.go
@@ -122,6 +122,9 @@ var ErrMetadataNeedsCredentials = errors.New("The keyring backend requires crede
 // ErrMetadataNotSupported is returned when Metadata is not available for the backend.
 var ErrMetadataNotSupported = errors.New("The keyring backend does not support metadata access")
 
+// ErrAccessDenied is returned by Keyring Get when access to Keychain is denied by the user
+var ErrAccessDenied = errors.New("Keyring backend access denied by user")
+
 var (
 	// Debug specifies whether to print debugging output.
 	Debug bool


### PR DESCRIPTION
We found a bug while making use of this package on the [cosmos-sdk](https://github.com/cosmos/cosmos-sdk). If a user denies to enter the password in the prompt while using keychain, a misleading error is returned (more info in the [issue](https://github.com/cosmos/cosmos-sdk/issues/10220)). This is because `errSecUserCanceled` is not being catch. This PR catch that error and return an expected error 

