### PR TITLE
Don't prompt for passphrase unless unlocking fails

### DIFF
--- a/file_test.go
+++ b/file_test.go
@@ -1,6 +1,7 @@
 package keyring
 
 import (
+	"errors"
 	"os"
 	"testing"
 )
@@ -8,7 +9,10 @@ import (
 func TestFileKeyringSetWhenEmpty(t *testing.T) {
 	k := &fileKeyring{
 		dir:          os.TempDir(),
-		passwordFunc: FixedStringPrompt("no more secrets"),
+		passwordFunc: func(_ string) (string, error) {
+			t.Fatal("passwordFunc called")
+			return "", errors.New("passwordFunc called")
+		},
 	}
 	item := Item{Key: "llamas", Data: []byte("llamas are great")}
 


### PR DESCRIPTION
Previously, the file backend treated the empty passphrase as passphrase unset and would unconditionally prompt the user for it. Only after hitting enter on the prompt would keyring attempt to use the empty passphrase.